### PR TITLE
New str2hax ip

### DIFF
--- a/Support/Guide/str2hax.001
+++ b/Support/Guide/str2hax.001
@@ -7,7 +7,7 @@ Requirements: a WiFi connection on your Wii, but does not require an SD card to 
 <li>Go to the "Wii Options" Menu, then select "Wii Settings", then go to Page 2 and select "Internet", select "Connection Settings", then choose your active connection.<br>
 <li>Select "Change settings" and scroll 3 times to the right to select "Auto-Obtain DNS" (Not IP Address)<br>
 <li>Select "No" then select "Advanced Settings".<br>
-<li><b>Change both the Primary DNS and Secondary DNS to <kbd>18.188.135.9</kbd></b><br>
+<li><b>Change both the Primary DNS and Secondary DNS to <kbd>3.143.163.250</kbd></b><br>
 	<ul style=align="left" type="disc">
 	<li>If you later have connection test issues or other problems google str2hax DNS to see if it has recently changed as it does from time to time.
 	</ul>

--- a/temp/updater.bat
+++ b/temp/updater.bat
@@ -35,7 +35,7 @@ if not errorlevel 1 move /y "temp\ARCME.zip" "temp\ARCME_1.0.5.zip"> nul
 :skiparcme
 
 ::update old str2hax DNS
-support\sfk filter "Support\Guide\str2hax.001" -rep _"173.201.71.14"_"18.188.135.9"_ -rep _"97.74.103.14"_"18.188.135.9"_ -write -yes>nul
+support\sfk filter "Support\Guide\str2hax.001" -rep _"173.201.71.14"_"3.143.163.250"_ -rep _"97.74.103.14"_"3.143.163.250"_ -rep _"18.188.135.9"_"3.143.163.250"_ -write -yes>nul
 
 ::Disable NUS Autopatcher since NUS back online
 goto:skip


### PR DESCRIPTION
str2hax is moving to a new IP. See [https://github.com/hacks-guide/Guide_Wii/pull/104](https://github.com/hacks-guide/Guide_Wii/pull/104) for more details.

I have not tested the updater.bat changes, if someone could verify they work that would be great.